### PR TITLE
Fix differing casing in package names considered unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.0 (Unreleased)
+
+Fixed same package names of differing case treated as unique ([#17](https://github.com/tetsuo13/CentralPackageManagementMigrator/issues/15))
+
 ## 1.0.0 (2024-09-23)
 
 Initial release

--- a/src/CentralPackageManagementMigrator/Builders/ProjectBuilder.cs
+++ b/src/CentralPackageManagementMigrator/Builders/ProjectBuilder.cs
@@ -88,16 +88,16 @@ internal class ProjectBuilder
 
     private void RemoveVersionOnPackageReferences(XmlDocument doc, List<NuGetPackageInfo> packages)
     {
-        foreach (var package in packages)
+        foreach (var packageId in packages.Select(x => x.Id))
         {
-            _logger.LogDebug("Locating single PackageReference for Includes = {PackageId}", package.Id);
-            var packageReference = doc.SelectSingleNode($"//PackageReference[@Include='{package.Id}']");
+            _logger.LogDebug("Locating single PackageReference for Includes = {PackageId}", packageId);
+            var packageReference = doc.SelectSingleNode($"//PackageReference[@Include='{packageId}']");
 
             // TODO: Should we do something here? Assumes it should always be found. Why wouldn't it though?
             _logger.LogDebug("Found element = {ElementFound}", packageReference is not null);
 
             packageReference?.Attributes?.Remove(packageReference.Attributes["Version"]);
-            _logger.LogInformation("Removed Version attribute for package {PackageId}", package.Id);
+            _logger.LogInformation("Removed Version attribute for package {PackageId}", packageId);
         }
     }
 

--- a/src/CentralPackageManagementMigrator/Builders/ProjectBuilder.cs
+++ b/src/CentralPackageManagementMigrator/Builders/ProjectBuilder.cs
@@ -21,7 +21,16 @@ internal class ProjectBuilder
         PreserveWhitespace = true
     };
 
-    public ReadOnlyDictionary<string, ReadOnlyCollection<NuGetPackageInfo>> GetPackagesInAllProjects(string searchPath)
+    /// <summary>
+    /// Recursively search for projects starting at a base directory to collect
+    /// all packages. Note that duplicates are not omitted.
+    /// </summary>
+    /// <param name="searchPath">The base directory to search for project files under.</param>
+    /// <returns>
+    /// Dictionary of project file paths to a collection of packages found in
+    /// that project.
+    /// </returns>
+    public ReadOnlyDictionary<string, List<NuGetPackageInfo>> GetPackagesInAllProjects(string searchPath)
     {
         const string searchPattern = "*.csproj";
 
@@ -29,7 +38,7 @@ internal class ProjectBuilder
         var allProjects = Directory.GetFiles(searchPath, searchPattern, SearchOption.AllDirectories);
         _logger.LogDebug("Found {Count} files", allProjects.Length);
 
-        var allPackages = new Dictionary<string, ReadOnlyCollection<NuGetPackageInfo>>();
+        var allPackages = new Dictionary<string, List<NuGetPackageInfo>>();
 
         _logger.LogInformation("Reading project files");
 
@@ -59,7 +68,7 @@ internal class ProjectBuilder
     /// <summary>
     /// For unit tests.
     /// </summary>
-    internal ReadOnlyCollection<NuGetPackageInfo> GetPackagesProjectSource(string projectSource)
+    internal List<NuGetPackageInfo> GetPackagesProjectSource(string projectSource)
     {
         var projectDocument = CreateXmlDocument();
         projectDocument.LoadXml(projectSource);
@@ -69,7 +78,7 @@ internal class ProjectBuilder
     /// <summary>
     /// For unit tests.
     /// </summary>
-    internal string UpdateProjectFromSource(string projectSource, ReadOnlyCollection<NuGetPackageInfo> packages)
+    internal string UpdateProjectFromSource(string projectSource, List<NuGetPackageInfo> packages)
     {
         var doc = CreateXmlDocument();
         doc.LoadXml(projectSource);
@@ -77,7 +86,7 @@ internal class ProjectBuilder
         return doc.OuterXml;
     }
 
-    private void RemoveVersionOnPackageReferences(XmlDocument doc, ReadOnlyCollection<NuGetPackageInfo> packages)
+    private void RemoveVersionOnPackageReferences(XmlDocument doc, List<NuGetPackageInfo> packages)
     {
         foreach (var package in packages)
         {
@@ -92,7 +101,7 @@ internal class ProjectBuilder
         }
     }
 
-    public void UpdateProjects(ReadOnlyDictionary<string, ReadOnlyCollection<NuGetPackageInfo>> projectPackages)
+    public void UpdateProjects(ReadOnlyDictionary<string, List<NuGetPackageInfo>> projectPackages)
     {
         _logger.LogInformation("Updating project files PackageReference elements");
 
@@ -111,7 +120,7 @@ internal class ProjectBuilder
         }
     }
 
-    private ReadOnlyCollection<NuGetPackageInfo> GetPackagesInProject(XmlDocument projectDocument)
+    private List<NuGetPackageInfo> GetPackagesInProject(XmlDocument projectDocument)
     {
         _logger.LogDebug("Checking for PackageReferences");
         var packageReferences = projectDocument.SelectNodes("//PackageReference");
@@ -119,13 +128,13 @@ internal class ProjectBuilder
 
         if (packageReferences is null || packageReferences.Count < 1)
         {
-            return ReadOnlyCollection<NuGetPackageInfo>.Empty;
+            return [];
         }
 
         return GetPackagesFromReferences(packageReferences);
     }
 
-    private ReadOnlyCollection<NuGetPackageInfo> GetPackagesFromReferences(XmlNodeList packageReferences)
+    private List<NuGetPackageInfo> GetPackagesFromReferences(XmlNodeList packageReferences)
     {
         var packagesInProject = new List<NuGetPackageInfo>();
 
@@ -154,6 +163,6 @@ internal class ProjectBuilder
             packagesInProject.Add(new NuGetPackageInfo(packageName, packageVersion));
         }
 
-        return packagesInProject.AsReadOnly();
+        return packagesInProject;
     }
 }

--- a/src/CentralPackageManagementMigrator/CentralPackageManagementMigrator.csproj
+++ b/src/CentralPackageManagementMigrator/CentralPackageManagementMigrator.csproj
@@ -7,9 +7,9 @@
     <Nullable>enable</Nullable>
     <PackageId>CentralPackageManagementMigrator</PackageId>
     <PackAsTool>true</PackAsTool>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <ToolCommandName>centralpackagemanagementmigrator</ToolCommandName>
-    <Copyright>Copyright 2024 Andrei Nicholson</Copyright>
+    <Copyright>Copyright 2024-2025 Andrei Nicholson</Copyright>
     <Authors>Andrei Nicholson</Authors>
     <PackageTags>NuGet;central;package;management;CentralPackageManagement;CPM;migrator</PackageTags>
     <Description>Migrates a codebase to use NuGet central package management (CPM)</Description>

--- a/src/CentralPackageManagementMigrator/CentralPackageManagementMigrator.csproj
+++ b/src/CentralPackageManagementMigrator/CentralPackageManagementMigrator.csproj
@@ -7,9 +7,9 @@
     <Nullable>enable</Nullable>
     <PackageId>CentralPackageManagementMigrator</PackageId>
     <PackAsTool>true</PackAsTool>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.0.0</VersionPrefix>
     <ToolCommandName>centralpackagemanagementmigrator</ToolCommandName>
-    <Copyright>Copyright 2024-2025 Andrei Nicholson</Copyright>
+    <Copyright>Copyright 2024 Andrei Nicholson</Copyright>
     <Authors>Andrei Nicholson</Authors>
     <PackageTags>NuGet;central;package;management;CentralPackageManagement;CPM;migrator</PackageTags>
     <Description>Migrates a codebase to use NuGet central package management (CPM)</Description>

--- a/src/CentralPackageManagementMigrator/LoggingUtility.cs
+++ b/src/CentralPackageManagementMigrator/LoggingUtility.cs
@@ -10,7 +10,7 @@ internal static class LoggingUtility
     private static ILoggerFactory? _loggerFactory;
     private static ILoggerFactory Factory
     {
-        get => _loggerFactory ?? throw new NullReferenceException($"Call {nameof(SetupLogging)} first");
+        get => _loggerFactory ?? throw new InvalidOperationException($"Call {nameof(SetupLogging)} first");
         set => _loggerFactory = value;
     }
 

--- a/src/CentralPackageManagementMigrator/MigratorCommand.cs
+++ b/src/CentralPackageManagementMigrator/MigratorCommand.cs
@@ -25,7 +25,7 @@ internal class MigratorCommand : Command
         LoggingUtility.SetupLogging(logLevel);
         var logger = LoggingUtility.CreateLogger<MigratorCommand>();
 
-        logger.LogDebug("Called with log level {LogLevel}", logLevel);
+        logger.LogDebug("Called with verbosity: {Level}", logLevel.ToString());
 
         var searchPath = Directory.GetCurrentDirectory();
         logger.LogInformation("Adding central package management under search path: {SearchPath}", searchPath);

--- a/src/CentralPackageManagementMigrator/MigratorCommand.cs
+++ b/src/CentralPackageManagementMigrator/MigratorCommand.cs
@@ -46,7 +46,9 @@ internal class MigratorCommand : Command
 
             if (packages.Count > 0)
             {
-                directoryPackagesProps.WriteFile(packages);
+                var distinctPackages = packages.ToDistinctOrder();
+
+                directoryPackagesProps.WriteFile(distinctPackages);
                 projectBuilder.UpdateProjects(packages);
             }
             else

--- a/src/CentralPackageManagementMigrator/NuGetPackageInfo.cs
+++ b/src/CentralPackageManagementMigrator/NuGetPackageInfo.cs
@@ -11,9 +11,10 @@ internal class NuGetPackageInfo : IEquatable<NuGetPackageInfo>
         Version = version;
     }
 
+    public override bool Equals(object? obj) => Equals(obj as NuGetPackageInfo);
     public bool Equals(NuGetPackageInfo? other)
     {
-        if (ReferenceEquals(null, other))
+        if (other is null)
         {
             return false;
         }
@@ -28,5 +29,4 @@ internal class NuGetPackageInfo : IEquatable<NuGetPackageInfo>
     }
 
     public override int GetHashCode() => HashCode.Combine(Id.ToLowerInvariant(), Version);
-    public override bool Equals(object? obj) => Equals(obj as NuGetPackageInfo);
 }

--- a/src/CentralPackageManagementMigrator/NuGetPackageInfo.cs
+++ b/src/CentralPackageManagementMigrator/NuGetPackageInfo.cs
@@ -1,6 +1,6 @@
 namespace CentralPackageManagementMigrator;
 
-internal record NuGetPackageInfo
+internal class NuGetPackageInfo : IEquatable<NuGetPackageInfo>
 {
     public string Id { get; }
     public string Version { get; }
@@ -10,4 +10,23 @@ internal record NuGetPackageInfo
         Id = id;
         Version = version;
     }
+
+    public bool Equals(NuGetPackageInfo? other)
+    {
+        if (ReferenceEquals(null, other))
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        return Id.Equals(other.Id, StringComparison.InvariantCultureIgnoreCase) &&
+               Version.Equals(other.Version);
+    }
+
+    public override int GetHashCode() => HashCode.Combine(Id.ToLowerInvariant(), Version);
+    public override bool Equals(object? obj) => Equals(obj as NuGetPackageInfo);
 }

--- a/src/CentralPackageManagementMigrator/NuGetPackageInfoExtensions.cs
+++ b/src/CentralPackageManagementMigrator/NuGetPackageInfoExtensions.cs
@@ -1,0 +1,50 @@
+using System.Collections.ObjectModel;
+using CentralPackageManagementMigrator.Builders;
+
+namespace CentralPackageManagementMigrator;
+
+/// <summary>
+/// Intermediary extensions used by Command class to prepare data structures
+/// between builders.
+/// </summary>
+internal static class NuGetPackageInfoExtensions
+{
+    /// <summary>
+    /// Extracts all collections of NuGetPackageInfo objects to return a
+    /// collection of distinct NuGetPackageInfo objects in order by name.
+    /// </summary>
+    /// <param name="packages">
+    /// The return from <see cref="ProjectBuilder.GetPackagesInAllProjects"/>,
+    /// a dictionary of each project and the packages used.
+    /// </param>
+    /// <returns></returns>
+    public static IEnumerable<NuGetPackageInfo> ToDistinctOrder(
+        this ReadOnlyDictionary<string, List<NuGetPackageInfo>> packages)
+    {
+        return packages.SelectMany(x => x.Value)
+
+            // Removes duplicates as defined by the implementation of
+            // IEquatable in NuGetPackageInfo.
+            .Distinct()
+
+            // If there are multiple versions of the same package, keeps only
+            // a single one.
+            .GroupBy(x => x.Id)
+            .Select(MinimumPackageVersion)
+
+            // Order by the package names.
+            .OrderBy(x => x.Id, StringComparer.InvariantCultureIgnoreCase);
+    }
+
+    /// <summary>
+    /// Finds the instance with the "lowest" version.
+    /// </summary>
+    /// <param name="arg">A grouping of instances with the same package ID.</param>
+    /// <returns>The instance with the lowest version.</returns>
+    private static NuGetPackageInfo MinimumPackageVersion(IGrouping<string, NuGetPackageInfo> arg)
+    {
+        // A naive algorithm. This will likely need to be reworked some day
+        // when encountering more complex examples.
+        return arg.OrderBy(x => x.Version).First();
+    }
+}

--- a/tests/CentralPackageManagementMigrator.Tests/Builders/PackagesPropsBuilderTests.cs
+++ b/tests/CentralPackageManagementMigrator.Tests/Builders/PackagesPropsBuilderTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using CentralPackageManagementMigrator.Builders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -10,16 +9,11 @@ namespace CentralPackageManagementMigrator.Tests.Builders;
 public class PackagesPropsBuilderTests
 {
     [Fact]
-    public void DistinctPackageIds()
+    public void BasicExample()
     {
-        var packages = new Dictionary<string, ReadOnlyCollection<NuGetPackageInfo>>
+        var packages = new List<NuGetPackageInfo>
         {
-            {
-                nameof(DistinctPackageIds),
-                new ReadOnlyCollection<NuGetPackageInfo>([
-                    new NuGetPackageInfo("Contoso.Utility.UsefulStuff", "17.9.0")
-                ])
-            }
+            new("Contoso.Utility.UsefulStuff", "17.9.0")
         };
 
         const string expected = """
@@ -37,174 +31,10 @@ public class PackagesPropsBuilderTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact]
-    public void PackageIdsInAlphabeticalOrder_SingleProject()
-    {
-        var packages = new Dictionary<string, ReadOnlyCollection<NuGetPackageInfo>>
-        {
-            {
-                nameof(PackageIdsInAlphabeticalOrder_SingleProject),
-                new ReadOnlyCollection<NuGetPackageInfo>([
-                    new NuGetPackageInfo("newtonsoft.json", "8.0.3"),
-                    new NuGetPackageInfo("jQuery", "3.1.1"),
-                    new NuGetPackageInfo("Some.Package", "1.0.0"),
-                    new NuGetPackageInfo("NuGet.Core", "2.11.1"),
-                    new NuGetPackageInfo("RouteMagic", "1.3"),
-                    new NuGetPackageInfo("Contoso.Utility.UsefulStuff", "17.9.0"),
-                    new NuGetPackageInfo("Microsoft.Web.Xdt", "2.1.1")
-                ])
-            }
-        };
-
-        const string expected = """
-                                <Project>
-                                  <PropertyGroup>
-                                    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                                  </PropertyGroup>
-                                  <ItemGroup>
-                                    <PackageVersion Include="Contoso.Utility.UsefulStuff" Version="17.9.0" />
-                                    <PackageVersion Include="jQuery" Version="3.1.1" />
-                                    <PackageVersion Include="Microsoft.Web.Xdt" Version="2.1.1" />
-                                    <PackageVersion Include="newtonsoft.json" Version="8.0.3" />
-                                    <PackageVersion Include="NuGet.Core" Version="2.11.1" />
-                                    <PackageVersion Include="RouteMagic" Version="1.3" />
-                                    <PackageVersion Include="Some.Package" Version="1.0.0" />
-                                  </ItemGroup>
-                                </Project>
-                                """;
-
-        var actual = GenerateXml(packages);
-        Assert.Equal(expected, actual);
-    }
-
-    [Fact]
-    public void PackageIdsInAlphabeticalOrder_MultipleProjects()
-    {
-        var packages = new Dictionary<string, ReadOnlyCollection<NuGetPackageInfo>>
-        {
-            {
-                "project1",
-                new ReadOnlyCollection<NuGetPackageInfo>([
-                    new NuGetPackageInfo("Newtonsoft.Json", "8.0.3"),
-                    new NuGetPackageInfo("Some.Package", "1.0.0"),
-                ])
-            },
-            {
-                "project2",
-                new ReadOnlyCollection<NuGetPackageInfo>([
-                    new NuGetPackageInfo("jQuery", "3.1.1"),
-                    new NuGetPackageInfo("RouteMagic", "1.3"),
-                    new NuGetPackageInfo("Microsoft.Web.Xdt", "2.1.1")
-                ])
-            },
-            {
-                "project3",
-                new ReadOnlyCollection<NuGetPackageInfo>([
-                    new NuGetPackageInfo("NuGet.Core", "2.11.1"),
-                    new NuGetPackageInfo("Contoso.Utility.UsefulStuff", "17.9.0"),
-                ])
-            },
-        };
-
-        const string expected = """
-                                <Project>
-                                  <PropertyGroup>
-                                    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                                  </PropertyGroup>
-                                  <ItemGroup>
-                                    <PackageVersion Include="Contoso.Utility.UsefulStuff" Version="17.9.0" />
-                                    <PackageVersion Include="jQuery" Version="3.1.1" />
-                                    <PackageVersion Include="Microsoft.Web.Xdt" Version="2.1.1" />
-                                    <PackageVersion Include="Newtonsoft.Json" Version="8.0.3" />
-                                    <PackageVersion Include="NuGet.Core" Version="2.11.1" />
-                                    <PackageVersion Include="RouteMagic" Version="1.3" />
-                                    <PackageVersion Include="Some.Package" Version="1.0.0" />
-                                  </ItemGroup>
-                                </Project>
-                                """;
-
-        var actual = GenerateXml(packages);
-        Assert.Equal(expected, actual);
-    }
-
-    [Fact]
-    public void MultiplePackageIds_SameVersion_AppearsOnlyOnce()
-    {
-        var packages = new Dictionary<string, ReadOnlyCollection<NuGetPackageInfo>>
-        {
-            {
-                "package1",
-                new ReadOnlyCollection<NuGetPackageInfo>([
-                    new NuGetPackageInfo("Contoso.Utility.UsefulStuff", "17.9.0")
-                ])
-            },
-            {
-                "package2",
-                new ReadOnlyCollection<NuGetPackageInfo>([
-                    new NuGetPackageInfo("Contoso.Utility.UsefulStuff", "17.9.0")
-                ])
-            }
-        };
-
-        const string expected = """
-                                <Project>
-                                  <PropertyGroup>
-                                    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                                  </PropertyGroup>
-                                  <ItemGroup>
-                                    <PackageVersion Include="Contoso.Utility.UsefulStuff" Version="17.9.0" />
-                                  </ItemGroup>
-                                </Project>
-                                """;
-
-        var actual = GenerateXml(packages);
-        Assert.Equal(expected, actual);
-    }
-
-    [Fact]
-    public void MultiplePackageIds_DifferentVersions_MinimumUsed()
-    {
-        var packages = new Dictionary<string, ReadOnlyCollection<NuGetPackageInfo>>
-        {
-            {
-                "package1",
-                new ReadOnlyCollection<NuGetPackageInfo>([
-                    new NuGetPackageInfo("Contoso.Utility.UsefulStuff", "17.9.0")
-                ])
-            },
-            {
-                "package2",
-                new ReadOnlyCollection<NuGetPackageInfo>([
-                    new NuGetPackageInfo("Contoso.Utility.UsefulStuff", "16.3.6")
-                ])
-            },
-            {
-                "package3",
-                new ReadOnlyCollection<NuGetPackageInfo>([
-                    new NuGetPackageInfo("Contoso.Utility.UsefulStuff", "18.0.0")
-                ])
-            }
-        };
-
-        const string expected = """
-                                <Project>
-                                  <PropertyGroup>
-                                    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                                  </PropertyGroup>
-                                  <ItemGroup>
-                                    <PackageVersion Include="Contoso.Utility.UsefulStuff" Version="16.3.6" />
-                                  </ItemGroup>
-                                </Project>
-                                """;
-
-        var actual = GenerateXml(packages);
-        Assert.Equal(expected, actual);
-    }
-
-    private static string GenerateXml(Dictionary<string, ReadOnlyCollection<NuGetPackageInfo>> packages)
+    private static string GenerateXml(List<NuGetPackageInfo> packages)
     {
         var logger = NullLoggerFactory.Instance.CreateLogger<PackagesPropsBuilder>();
         var builder =  new PackagesPropsBuilder(logger, nameof(GenerateXml));
-        return builder.GenerateXml(packages.AsReadOnly());
+        return builder.GenerateXml(packages);
     }
 }

--- a/tests/CentralPackageManagementMigrator.Tests/Builders/ProjectBuilderTests.cs
+++ b/tests/CentralPackageManagementMigrator.Tests/Builders/ProjectBuilderTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using CentralPackageManagementMigrator.Builders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -79,12 +78,12 @@ public class ProjectBuilderTests
                                  """;
 
         var projectBuilder = GetBuilder();
-        var actual = projectBuilder.UpdateProjectFromSource(csproj, packages.AsReadOnly());
+        var actual = projectBuilder.UpdateProjectFromSource(csproj, packages);
 
         Assert.Equal(expected, actual);
     }
 
-    private static ReadOnlyCollection<NuGetPackageInfo> GetPackagesProjectSource(string csproj)
+    private static List<NuGetPackageInfo> GetPackagesProjectSource(string csproj)
     {
         var projectBuilder = GetBuilder();
         return projectBuilder.GetPackagesProjectSource(csproj);

--- a/tests/CentralPackageManagementMigrator.Tests/NuGetPackageInfoTests.cs
+++ b/tests/CentralPackageManagementMigrator.Tests/NuGetPackageInfoTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace CentralPackageManagementMigrator.Tests;
@@ -11,10 +13,137 @@ public class NuGetPackageInfoTests
     [InlineData("NUnit", "1.2.3", "NUnit", "4.5.6", false)]
     [InlineData("Contoso.Utility.UsefulStuff", "4.5.6", "jQuery", "3.1.1", false)]
     [InlineData("Contoso.Utility.UsefulStuff", "4.5.6", "jQuery", "4.5.6", false)]
-    public void Equality(string leftId, string leftVersion, string rightId, string rightVersion, bool expected)
+    public void Equality(string leftId, string leftVersion, string rightId, string rightVersion, bool shouldBeEqual)
     {
         var left = new NuGetPackageInfo(leftId, leftVersion);
         var right = new NuGetPackageInfo(rightId, rightVersion);
-        Assert.Equal(expected, left.Equals(right));
+        Assert.Equal(shouldBeEqual, left.Equals(right));
     }
+
+    [Fact]
+    public void EqualityUsingLinqDistinct()
+    {
+        List<NuGetPackageInfo> packages =
+        [
+            new("NUnit", "1.2.3"),
+            new("Contoso.Utility.UsefulStuff", "4.5.6"),
+            new("nunit", "1.2.3")
+        ];
+
+        var actual = packages.Distinct().ToList();
+
+        Assert.Equal(2, actual.Count);
+        Assert.Same(packages[0], actual[0]);
+        Assert.Same(packages[1], actual[1]);
+    }
+
+    [Fact]
+    public void ToDistinctOrder()
+    {
+        var packages = new Dictionary<string, List<NuGetPackageInfo>>
+        {
+            { "ProjectA", [new NuGetPackageInfo("NUnit", "1.2.3"), new NuGetPackageInfo("NUnit", "4.5.6")] }
+        };
+
+        var actual = Transform(packages);
+
+        Assert.Single(actual);
+        Assert.Equal("1.2.3", actual[0].Version);
+    }
+
+    [Fact]
+    public void ToDistinctOrder_MultiplePackageIds_DifferentVersions_MinimumUsed()
+    {
+        var packages = new Dictionary<string, List<NuGetPackageInfo>>
+        {
+            {
+                "ProjectA",
+                [
+                    new NuGetPackageInfo("Contoso.Utility.UsefulStuff", "17.9.0"),
+                    new NuGetPackageInfo("Contoso.Utility.UsefulStuff", "16.3.6"),
+                    new NuGetPackageInfo("Contoso.Utility.UsefulStuff", "18.0.0")
+                ]
+            }
+        };
+
+        var actual = Transform(packages);
+
+        Assert.Single(actual);
+        Assert.Equal("16.3.6", actual[0].Version);
+    }
+
+    [Fact]
+    public void ToDistinctOrder_PackageIdsInAlphabeticalOrder_MultipleProjects()
+    {
+        var packages = new Dictionary<string, List<NuGetPackageInfo>>
+        {
+            {
+                "project1",
+                [
+                    new NuGetPackageInfo("Newtonsoft.Json", "8.0.3"),
+                    new NuGetPackageInfo("Some.Package", "1.0.0")
+                ]
+            },
+            {
+                "project2",
+                [
+                    new NuGetPackageInfo("jQuery", "3.1.1"),
+                    new NuGetPackageInfo("RouteMagic", "1.3"),
+                    new NuGetPackageInfo("Microsoft.Web.Xdt", "2.1.1")
+                ]
+            },
+            {
+                "project3",
+                [
+                    new NuGetPackageInfo("NuGet.Core", "2.11.1"),
+                    new NuGetPackageInfo("Contoso.Utility.UsefulStuff", "17.9.0")
+                ]
+            }
+        };
+
+        var actual = Transform(packages);
+
+        Assert.Equal(7, actual.Count);
+        Assert.Equal("Contoso.Utility.UsefulStuff", actual[0].Id);
+        Assert.Equal("jQuery", actual[1].Id);
+        Assert.Equal("Microsoft.Web.Xdt", actual[2].Id);
+        Assert.Equal("Newtonsoft.Json", actual[3].Id);
+        Assert.Equal("NuGet.Core", actual[4].Id);
+        Assert.Equal("RouteMagic", actual[5].Id);
+        Assert.Equal("Some.Package", actual[6].Id);
+    }
+
+    [Fact]
+    public void ToDistinctOrder_PackageIdsInAlphabeticalOrder_SingleProject()
+    {
+        var packages = new Dictionary<string, List<NuGetPackageInfo>>
+        {
+            {
+                "project1",
+                [
+                    new NuGetPackageInfo("newtonsoft.json", "8.0.3"),
+                    new NuGetPackageInfo("jQuery", "3.1.1"),
+                    new NuGetPackageInfo("Some.Package", "1.0.0"),
+                    new NuGetPackageInfo("NuGet.Core", "2.11.1"),
+                    new NuGetPackageInfo("RouteMagic", "1.3"),
+                    new NuGetPackageInfo("Contoso.Utility.UsefulStuff", "17.9.0"),
+                    new NuGetPackageInfo("Microsoft.Web.Xdt", "2.1.1")
+                ]
+            }
+        };
+
+        var actual = Transform(packages);
+
+        Assert.Equal(7, actual.Count);
+        Assert.Equal("Contoso.Utility.UsefulStuff", actual[0].Id);
+        Assert.Equal("jQuery", actual[1].Id);
+        Assert.Equal("Microsoft.Web.Xdt", actual[2].Id);
+        Assert.Equal("newtonsoft.json", actual[3].Id);
+        Assert.Equal("NuGet.Core", actual[4].Id);
+        Assert.Equal("RouteMagic", actual[5].Id);
+        Assert.Equal("Some.Package", actual[6].Id);
+    }
+
+    private static List<NuGetPackageInfo> Transform(Dictionary<string, List<NuGetPackageInfo>> packages) =>
+        packages.AsReadOnly().ToDistinctOrder().ToList();
 }

--- a/tests/CentralPackageManagementMigrator.Tests/NuGetPackageInfoTests.cs
+++ b/tests/CentralPackageManagementMigrator.Tests/NuGetPackageInfoTests.cs
@@ -1,0 +1,20 @@
+using Xunit;
+
+namespace CentralPackageManagementMigrator.Tests;
+
+public class NuGetPackageInfoTests
+{
+    [Theory]
+    [InlineData("NUnit", "1.2.3", "nunit", "1.2.3", true)]
+    [InlineData("NUnit", "1.2.3", "nunit", "4.5.6", false)]
+    [InlineData("NUnit", "1.2.3", "NUnit", "1.2.3", true)]
+    [InlineData("NUnit", "1.2.3", "NUnit", "4.5.6", false)]
+    [InlineData("Contoso.Utility.UsefulStuff", "4.5.6", "jQuery", "3.1.1", false)]
+    [InlineData("Contoso.Utility.UsefulStuff", "4.5.6", "jQuery", "4.5.6", false)]
+    public void Equality(string leftId, string leftVersion, string rightId, string rightVersion, bool expected)
+    {
+        var left = new NuGetPackageInfo(leftId, leftVersion);
+        var right = new NuGetPackageInfo(rightId, rightVersion);
+        Assert.Equal(expected, left.Equals(right));
+    }
+}


### PR DESCRIPTION
This PR changes the point where packages are being ordered and analyzed. Instead of that occurring in `PackagePropsBuilder` it's now expected to occur at the Command level. There, it's expected that the result from `ProjectBuilder`'s analysis of all packages from all projects to be filtered and the result of that passed to `PackagePropsBuilder`.

Since there are no unit tests around the Command class a new extension method is introduced which encapsulates all of the logic being performed to NuGet packages, `ToDistinctOrder()`.

There are some nice improvements as a result of this little PR:

- The large data structure that was returned from `ProjectBuilder`'s analysis is no longer being passed around to `PackagePropsBuilder` where it has to know how to read it. Instead, a simple `IEnumerable<NuGetPackageInfo>` is used since that's all it needs to know about.
- Additionally, `PackagePropsBuilder` can just focus on one thing: writing a set of packages to a file. It no longer needs to have logic for organizing those packages first in any way.
- The new extension method that does all of the work around uniqueness and ordering of NuGet packages provides a lot of opportunities later for dealing with complexities not-yet-discovered. The previous approach was easier to understand but didn't have a lot of wiggle room for changes or additions, so this was bound to be a problem sooner rather than later.